### PR TITLE
✨ feat: Support `**` glob pattern for matching nested submodules

### DIFF
--- a/python_dependency_linter/matcher.py
+++ b/python_dependency_linter/matcher.py
@@ -6,17 +6,29 @@ from python_dependency_linter.config import AllowDeny, Rule
 def matches_pattern(pattern: str, module: str) -> bool:
     pattern_parts = pattern.split(".")
     module_parts = module.split(".")
+    return _match(pattern_parts, module_parts)
 
-    if len(pattern_parts) != len(module_parts):
+
+def _match(pattern_parts: list[str], module_parts: list[str]) -> bool:
+    if not pattern_parts and not module_parts:
+        return True
+    if not pattern_parts:
         return False
 
-    for p, m in zip(pattern_parts, module_parts):
-        if p == "*":
-            continue
-        if p != m:
-            return False
+    if pattern_parts[0] == "**":
+        # "**" matches one or more parts
+        for i in range(1, len(module_parts) + 1):
+            if _match(pattern_parts[1:], module_parts[i:]):
+                return True
+        return False
 
-    return True
+    if not module_parts:
+        return False
+
+    if pattern_parts[0] == "*" or pattern_parts[0] == module_parts[0]:
+        return _match(pattern_parts[1:], module_parts[1:])
+
+    return False
 
 
 def find_matching_rules(module: str, rules: list[Rule]) -> list[Rule]:

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -17,6 +17,38 @@ def test_matches_pattern_wildcard():
     assert matches_pattern("contexts.*.domain", "contexts.boards.application") is False
 
 
+def test_matches_pattern_double_star():
+    # matches one level
+    assert matches_pattern("contexts.**.domain", "contexts.analytics.domain") is True
+    # matches multiple levels
+    assert (
+        matches_pattern("contexts.**.domain", "contexts.analytics.sub.domain") is True
+    )
+    # does not match zero levels (** requires one or more)
+    assert matches_pattern("contexts.**.domain", "contexts.domain") is False
+    # does not match wrong suffix
+    assert (
+        matches_pattern("contexts.**.domain", "contexts.analytics.application") is False
+    )
+
+
+def test_matches_pattern_double_star_at_end():
+    assert (
+        matches_pattern("contexts.**.domain.**", "contexts.a.domain.entities") is True
+    )
+    assert (
+        matches_pattern("contexts.**.domain.**", "contexts.a.domain.entities.metric")
+        is True
+    )
+    assert matches_pattern("contexts.**.domain.**", "contexts.a.domain") is False
+
+
+def test_matches_pattern_double_star_alone():
+    # ** alone matches any module with one or more parts
+    assert matches_pattern("**", "anything") is True
+    assert matches_pattern("**", "a.b.c") is True
+
+
 def test_matches_pattern_wildcard_in_allow():
     assert matches_pattern("contexts.*.domain", "contexts.boards.domain") is True
 


### PR DESCRIPTION
## Summary
- Support `**` glob pattern in `matches_pattern` to match nested submodules
- `**` matches one or more levels (same semantics as filesystem globstar)
- Existing `*` (single-level matching) behavior is preserved

Closes #4

## Test plan
- [x] Existing `*` pattern tests pass
- [x] `**` in middle position (`contexts.**.domain`)
- [x] `**` at end position (`contexts.**.domain.**`)
- [x] `**` standalone usage
- [x] ruff lint/format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)