### PR TITLE
🐛 fix: Allow dot (.) in rule names

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -21,7 +21,7 @@ The `name` is used in violation output and in `# pdl: ignore` comments. The opti
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Unique identifier. Must match `[a-zA-Z0-9_-]+`. Shown in violation output and referenced in `# pdl: ignore` comments |
+| `name` | Yes | Unique identifier. Must match `[a-zA-Z0-9_.-]+`. Shown in violation output and referenced in `# pdl: ignore` comments |
 | `modules` | Yes | Module pattern to apply the rule to. Supports `*`, `**`, and `{name}` captures (see [Patterns](#patterns)) |
 | `description` | No | Human-readable description shown in violation output |
 | `allow` | No | Whitelist of allowed dependencies (see [Allow / Deny](#allow-deny)) |

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -14,7 +14,7 @@ Complete reference for all configuration fields.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | str | Yes | — | Rule identifier, shown in violation output. Must match `[a-zA-Z0-9_-]+` |
+| `name` | str | Yes | — | Rule identifier, shown in violation output. Must match `[a-zA-Z0-9_.-]+` |
 | `modules` | str | Yes | — | Module pattern to apply the rule to. Supports `*`, `**`, and `{name}` captures |
 | `description` | str | No | `null` | Human-readable description shown in violation output |
 | `allow` | [DependencyFilter](#dependencyfilter) | No | `null` | Whitelist of allowed dependencies |

--- a/python_dependency_linter/config.py
+++ b/python_dependency_linter/config.py
@@ -40,7 +40,7 @@ def _parse_allow_deny(data: dict | None) -> AllowDeny | None:
     )
 
 
-_RULE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_RULE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_.\-]+$")
 
 
 def _parse_rules(rules_data: list[dict]) -> list[Rule]:
@@ -49,7 +49,7 @@ def _parse_rules(rules_data: list[dict]) -> list[Rule]:
         name = r["name"]
         if not _RULE_NAME_PATTERN.match(name):
             raise ValueError(
-                f"Invalid rule name '{name}'. Rule names must match [a-zA-Z0-9_-]+"
+                f"Invalid rule name '{name}'. Rule names must match [a-zA-Z0-9_.-]+"
             )
         rules.append(
             Rule(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,11 +141,15 @@ rules:
     modules: src.*
   - name: rule1
     modules: src.*
+  - name: shared.domain
+    modules: src.*
+  - name: context.adapters.inbound
+    modules: src.*
 """
     config_file = tmp_path / "config.yaml"
     config_file.write_text(config_content)
     config = load_config(config_file)
-    assert len(config.rules) == 3
+    assert len(config.rules) == 5
 
 
 def test_invalid_rule_name_with_space(tmp_path):


### PR DESCRIPTION
## Summary
- Expand rule name validation regex from `[a-zA-Z0-9_-]+` to `[a-zA-Z0-9_.-]+` to allow dot-separated rule names like `shared.domain`
- Update error message and documentation
- Add tests for dot-containing rule names

Closes #27

## Test plan
- [x] All existing tests pass
- [x] Added tests for dot-containing rule names (`shared.domain`, `context.adapters.inbound`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)